### PR TITLE
Feat(api): Provide stats endpoint for tenant

### DIFF
--- a/lib/lotta/tenants.ex
+++ b/lib/lotta/tenants.ex
@@ -6,9 +6,11 @@ defmodule Lotta.Tenants do
 
   import Ecto.Query
 
+  alias LottaWeb.Schema.Tenants.Tenant
   alias Ecto.Multi
   alias Lotta.{Email, Mailer, Repo, Storage, TenantSelector}
   alias Lotta.Accounts.User
+  alias Lotta.Content.Article
   alias Lotta.Storage.File
 
   alias Lotta.Tenants.{
@@ -176,6 +178,31 @@ defmodule Lotta.Tenants do
     tenant
     |> Tenant.update_changeset(args)
     |> Repo.update()
+  end
+
+  @doc """
+  Get a few interesting stats for a given tenant.
+  These are:
+  - user count
+  - article count
+  - category count
+  - file count
+
+  ## Examples
+
+    iex> get_stats(tenant)
+    %{user_count: 123, article_count: 456, category_count: 789, file_count: 1011}
+
+  """
+  @doc since: "4.2.0"
+  @spec get_stats(Tenant.t()) :: Tenant.stats()
+  def get_stats(%Tenant{prefix: prefix}) do
+    %{
+      user_count: Repo.aggregate(User, :count, prefix: prefix),
+      article_count: Repo.aggregate(Article, :count, prefix: prefix),
+      category_count: Repo.aggregate(Category, :count, prefix: prefix),
+      file_count: Repo.aggregate(File, :count, prefix: prefix)
+    }
   end
 
   @doc """

--- a/lib/lotta/tenants/tenant.ex
+++ b/lib/lotta/tenants/tenant.ex
@@ -10,6 +10,13 @@ defmodule Lotta.Tenants.Tenant do
 
   @type id() :: pos_integer()
 
+  @type stats() :: %{
+          user_count: pos_integer(),
+          article_count: pos_integer(),
+          category_count: pos_integer(),
+          file_count: pos_integer()
+        }
+
   @type configuration() :: %{
           custom_theme: map() | nil,
           logo_image_file: File.t() | nil,

--- a/lib/lotta_web/resolvers/tenant_resolver.ex
+++ b/lib/lotta_web/resolvers/tenant_resolver.ex
@@ -40,4 +40,8 @@ defmodule LottaWeb.TenantResolver do
   def host(_, %{context: %{tenant: tenant}}) do
     {:ok, Urls.get_tenant_host(tenant)}
   end
+
+  def get_stats(_, %{context: %{tenant: tenant}}) do
+    {:ok, Tenants.get_stats(tenant)}
+  end
 end

--- a/lib/lotta_web/schema/tenants/tenant.ex
+++ b/lib/lotta_web/schema/tenants/tenant.ex
@@ -13,6 +13,12 @@ defmodule LottaWeb.Schema.Tenants.Tenant do
     field :inserted_at, :datetime
     field :host, :string, resolve: &TenantResolver.host/2
 
+    field :stats, :tenant_stats do
+      middleware(LottaWeb.Schema.Middleware.EnsureUserIsAdministrator)
+
+      resolve(&TenantResolver.get_stats/2)
+    end
+
     field :custom_domains, list_of(:custom_domain), resolve: &TenantResolver.custom_domains/2
   end
 
@@ -29,6 +35,13 @@ defmodule LottaWeb.Schema.Tenants.Tenant do
     field :logo_image_file, :file
     field :custom_theme, :json
     field :user_max_storage_config, :string
+  end
+
+  object :tenant_stats do
+    field :user_count, :integer
+    field :article_count, :integer
+    field :category_count, :integer
+    field :file_count, :integer
   end
 
   input_object :tenant_input do


### PR DESCRIPTION
Ein Tenant hat nun 'stats' property, die ausschließlich von Administratoren über die gql-API abgefragt werden kann. Dieses Objekt gibt zurück:

- Anzahl angemeldeter Nutzer
- Anzahl Beiträge
- Anzahl Kategorien
- Anzahl hochgeladener Dateien

Dies geschieht in Vorbereitung zur Lösung von https://github.com/lotta-schule/web/issues/122, für das die Anzahl der angemeldeten Nutzer abgefragt werden muss.